### PR TITLE
Fix focus.cs error for collider-less controllers

### DIFF
--- a/Powertools/Focus.cs
+++ b/Powertools/Focus.cs
@@ -92,8 +92,11 @@ namespace DeluxePlugin.Powertools {
             controller.meshScale = visible ? DEFAULT_SCALE : 0.0f;
 
             SphereCollider collider = controller.GetComponent<SphereCollider>();
-            collider.radius = visible ? 0.11f : 0.0f;
-            collider.enabled = visible;
+            if (collider)
+            {
+                collider.radius = visible ? 0.11f : 0.0f;
+                collider.enabled = visible;
+            }
 
             if (visible)
             {


### PR DESCRIPTION
This fixes the Focus plugin for scenes where some atom has controllers without a collider, like certain non-Person atoms.

Without this fix, when enabled, Focus will usually throw a null reference exception and only work for the currently selected Person atom.
